### PR TITLE
Added hyva_catalogsearch_result_index.xml to remove default filters

### DIFF
--- a/src/view/frontend/layout/hyva_catalogsearch_result_index.xml
+++ b/src/view/frontend/layout/hyva_catalogsearch_result_index.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="sidebar.main">
+            <referenceBlock name="catalogsearch.leftnav" remove="true"/>
+        </referenceContainer>
+    </body>
+</page>


### PR DESCRIPTION
Added hyva_catalogsearch_result_index.xml 
to remove name="catalogsearch.leftnav" default magento's sidebar filters, and keep only algolia's instant search filters