### PR TITLE
Update autocomplete.js use insertAdjacentHTML

### DIFF
--- a/src/view/frontend/web/js/autocomplete.js
+++ b/src/view/frontend/web/js/autocomplete.js
@@ -538,7 +538,7 @@ function initAlgoliaAutocomplete() {
     algoliaAutocompleteInstance = algolia.triggerHooks('afterAutocompleteStart', algoliaAutocompleteInstance);
 
     if (algoliaConfig.autocomplete.isNavigatorEnabled) {
-        document.body.append('<style>.aa-Item[aria-selected="true"]{background-color: #f2f2f2;}</style>');
+        document.body.insertAdjacentHTML('beforeend', "<style>.aa-Item[aria-selected='true']{background-color: #f2f2f2;}</style>");
     }
 
 }


### PR DESCRIPTION
Issue:

append: Is adding plain text to the end of body
```
document.body.append('<style>.aa-Item[aria-selected="true"]{background-color: #f2f2f2;}</style>');
```

Fix: 

Replace it  with insertAdjacentHTML

```
document.body.insertAdjacentHTML('beforeend', "<style>.aa-Item[aria-selected='true']{background-color: #f2f2f2;}</style>");
```