### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "algolia/algoliasearch-magento-2": "^3.12",
         "blackbird/external-resources-loader": "^1.0",
 	"hyva-themes/magento2-compat-module-fallback": "*",
-        "hyva-themes/magento2-default-theme": "*"
+        "hyva-themes/magento2-default-theme": "^1.3.6"
     },
     "authors": [
         {


### PR DESCRIPTION
The `/src/view/frontend/templates/instant/hit.phtml` depends on a Hyva [feature](https://docs.hyva.io/hyva-themes/writing-code/rendering-javascript-once.html) introduced in version 1.3.6. On lower versions, the class `BlockJsDependencies` doesn't exists.