### PR TITLE
remove 1column layout from hyva_algolia_search_handle.xml

### DIFF
--- a/src/view/frontend/layout/hyva_algolia_search_handle.xml
+++ b/src/view/frontend/layout/hyva_algolia_search_handle.xml
@@ -1,4 +1,4 @@
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column"
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <head>
         <remove src="Algolia_AlgoliaSearch::css/grid.css"/>


### PR DESCRIPTION
this layout directive use the 1column everywhere in the account removing the sidebar